### PR TITLE
Improve PowerShell setup debugability

### DIFF
--- a/scripts/powershell_cleanup.ps1
+++ b/scripts/powershell_cleanup.ps1
@@ -33,4 +33,4 @@ function CleanUpProfileContent()
 CleanUpProfileContent
 CleanUpOpenAiConfig
 
-Write-Host -ForegroundColor Blue "NL-CLI PowerShell clean up completed. Please close this powershell session."
+Write-Host -ForegroundColor Blue "NL-CLI PowerShell clean up completed. Please close this PowerShell session."

--- a/scripts/powershell_setup.ps1
+++ b/scripts/powershell_setup.ps1
@@ -93,4 +93,4 @@ secret_key=$openAIApiKeyPlainText
 engine=$OpenAIEngine"
 Write-Host "Updated OpenAI configuration file with secrets."
 
-Write-Host -ForegroundColor Blue "NL-CLI PowerShell (v$PSMajorVersion) setup completed. Please open a new powershell session, type in # followed by your natural language command and hit Ctrl+X!"
+Write-Host -ForegroundColor Blue "NL-CLI PowerShell (v$PSMajorVersion) setup completed. Please open a new PowerShell session, type in # followed by your natural language command and hit Ctrl+X!"


### PR DESCRIPTION
Add check for OpenAI api access and model in the PowerShell setup script.
* Send request to engines API with given api key and org id to verify if they are valid. exit the setup if response isn't HTTP 200.
* From the engines API, find if the given model id is present. exit the setup if cannot find the given model.

Tested in PS5 and PS7.
* Invalid access key or org id
![image](https://user-images.githubusercontent.com/4814277/163652484-bd07dfb5-cc3b-491f-8892-99d5b03987e1.png)
* Invalid model id (often happened when the user doens't have permission to the model)
![image](https://user-images.githubusercontent.com/4814277/163652549-35e83930-4549-41f3-ba34-b771b543041e.png)
* Success path
![image](https://user-images.githubusercontent.com/4814277/163652567-97cd6a03-8ec1-450b-8a53-0c43bcba9ea5.png)
*Note*: "powershell" has been corrected to "PowerShell" in the code

Add success message for clean up.
![image](https://user-images.githubusercontent.com/4814277/163652590-b70add4e-8b93-4f8c-b3b2-8fa489c972fd.png)
*Note*: "powershell" has been corrected to "PowerShell" in the code


