### PR TITLE
Fix for #49, 55

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Set-ExecutionPolicy RemoteSigned -Scope CurrentUser
 ```
 .\scripts\powershell_setup.ps1 -OpenAIOrganizationId "YOUR_OPENAI_ORGANIZATION_ID" -OpenAIEngineId "ENGINE_ID"
 ```
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;See [About powershell_setup.ps1](#about-powershellsetupps1) section to learn script parameters.
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;See [About powershell_setup.ps1](#about-powershell_setupps1) section to learn script parameters.
 
 4. Open a new powershell session, type in `#` followed by your natural language command and hit Ctrl+X!
 


### PR DESCRIPTION
Fix for #49 and #55.
1. Make OpenAI key, org id, engine id as clear requirements with hyperlinks to OpenAI pages to get the value.
2. Update python pkg installation commands to consider David's case.