### PR TITLE
automatically comment natural language command in PS

### DIFF
--- a/scripts/powershell_plugin.ps1
+++ b/scripts/powershell_plugin.ps1
@@ -28,10 +28,15 @@ Set-PSReadLineKeyHandler -Key Ctrl+g `
 
     [Microsoft.PowerShell.PSConsoleReadLine]::GetBufferState([ref]$line, [ref]$cursor)
 
+    # move to the beginning of the line and insert '#'
+    [Microsoft.PowerShell.PSConsoleReadLine]::BeginningOfLine()
+    [Microsoft.PowerShell.PSConsoleReadLine]::Insert("# ")
+    
     # get response from create_completion function
     $output = create_completion($line)
     
-    # check if output is not null
+    # insert responses after end of line if available
+    [Microsoft.PowerShell.PSConsoleReadLine]::EndOfLine()
     if ($output -ne $null) {
         foreach ($str in $output) {
             if ($str -ne $null -and $str -ne "") {

--- a/src/codex_query.py
+++ b/src/codex_query.py
@@ -143,6 +143,11 @@ def get_query(prompt_file):
         entry = input("prompt: ") + '\n'
     else:
         entry = sys.stdin.read()
+    
+    # check if entry starts with # otherwise add it to entry
+    if entry.startswith('#') == False:
+        entry = "# " + entry
+    
     # first we check if the input is a command
     command_result, prompt_file = get_command_result(entry, prompt_file)
 


### PR DESCRIPTION
Now we don't have to add `#` before every natural language command in powershell. It will be added automatically.