### PR TITLE
Add progress when executing query

### DIFF
--- a/scripts/powershell_plugin.ps1
+++ b/scripts/powershell_plugin.ps1
@@ -12,7 +12,9 @@ function create_completion() {
         return "`nnotepad $profile"
     }
 
+    write-progress -id 1 -activity "Codex query"
     $output = echo -n $buffer | python $nl_cli_script 
+    write-progress -id 1 -activity "Codex query" -completed
     
     return $output
 }


### PR DESCRIPTION
After hitting `ctrl+g`, it can take some time for a response so it's not clear if anything is happening.  Suggestion is to show a progress bar to indicate something is happening but may take a few seconds.