### PR TITLE
Documentation fixes

### DIFF
--- a/Installation.md
+++ b/Installation.md
@@ -103,7 +103,7 @@ source bash_setup.sh -h
 1. Download this project to `~/your/custom/path/`.
 
 ```
-    $ git clone https://github.com/microsoft/Codex-CLI.git ~/your/custom/path/
+$ git clone https://github.com/microsoft/Codex-CLI.git ~/your/custom/path/
 ```
 
 2. In zsh, go to `~/your/custom/path/` (the folder contains Codex CLI code), then run the following command to setup your zsh environment. The script will prompt for Organization id, API key and engine id:

--- a/Installation.md
+++ b/Installation.md
@@ -65,7 +65,7 @@ To leverage the Codex CLI on WSL and Linux environments using Bash please follow
 	
 	The script will create an OpenAI config file and update your bash environment.
 
-4. Open a new Bash terminal. Type in `#` followed by your natural language request. Press Ctrl+g to execute!
+4. Open a new Bash terminal. Type in `#` followed by your natural language request. Press `Ctrl + G` to execute!
 
 ### Clean up
 
@@ -155,7 +155,7 @@ For more information about Execution Policies, see
 ```
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;See [About powershell_setup.ps1](#about-powershell_setupps1) section to learn script parameters.
 
-4. Open a new PowerShell session, type in `#` followed by your natural language command and hit Ctrl + G!
+4. Open a new PowerShell session, type in `#` followed by your natural language command and hit `Ctrl + G`!
 
 ### Clean up
 Once you are done, go to `C:\your\custom\path\` (the folder that contains the cloned Codex CLI project), then run the following command to clean up.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Codex CLI - Natural Language Command Line Interface
 
-This project uses [GPT-3 Codex](https://openai.com/blog/openai-codex/) to convert natural language commands into commands in PowerShell, Zshell and Bash. 
+This project uses [GPT-3 Codex](https://openai.com/blog/openai-codex/) to convert natural language commands into commands in PowerShell, Z shell and Bash.
 
 ![Codex Cli GIF](codex_cli.gif)
 
@@ -97,12 +97,11 @@ This project comes pre-loaded with contexts for each shell, along with some bonu
 ```bash
 # make a K8s cluster IP called my-cs running on 5678:8080
 kubectl create service clusterip my-cs --tcp=5678:8080
-
 ```
 
 Add your context to the `contexts` folder and run `load context <filename>` to load it. You can also change the default context from to your context file inside `src\prompt_file.py`.
 
-Note that Codex will often produce correct scripts without any examples. Having been trained on a large corpus of code, it frequently knows how to produce specific commands. That said, building your own contexts helps coax the specific kind of script you're looking for - whether it's long or short, whether it declares variables or not, whether it refers back to previous commands, etc. You can also provide examples of your own CLI commmands and scripts, to show Codex other tools it should consider using.
+Note that Codex will often produce correct scripts without any examples. Having been trained on a large corpus of code, it frequently knows how to produce specific commands. That said, building your own contexts helps coax the specific kind of script you're looking for - whether it's long or short, whether it declares variables or not, whether it refers back to previous commands, etc. You can also provide examples of your own CLI commands and scripts, to show Codex other tools it should consider using.
 
 One important thing to consider is that if you add a new context, keep the multi-turn mode on to avoid our automatic defaulting (which was added to keep faulty contexts from breaking your experience).
 

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ The Command Line Interface (CLI) was the first major User Interface we used to i
 
 With the advent of Large Language Models (LLMs), particularly those that have been trained on code, it's possible to interact with a CLI using Natural Language (NL). In effect, these models understand natural language _and_ code well enough that they can translate from one to another. 
 
-This project aims to offer a cross-shell NL->Code experience to allow users to interact with their favorite CLI using NL. The user enters a command, like "what's my IP address", hits Ctrl + G and gets a suggestion for a command idiomatic to the shell they're using. The project uses the GPT-3 Codex model off-the-shelf, meaning the model has not been explicitly trained for the task. Instead we rely on a discipline called prompt engineering (see [section](#prompt-engineering-and-context-files) below) to coax the right commands from Codex. 
+This project aims to offer a cross-shell NL->Code experience to allow users to interact with their favorite CLI using NL. The user enters a command, like "what's my IP address", hits `Ctrl + G` and gets a suggestion for a command idiomatic to the shell they're using. The project uses the GPT-3 Codex model off-the-shelf, meaning the model has not been explicitly trained for the task. Instead we rely on a discipline called prompt engineering (see [section](#prompt-engineering-and-context-files) below) to coax the right commands from Codex. 
 
-**Note: The model can still make mistakes! Don't run a command if you don't understand it. If you're not sure what a command does, hit 'Ctrl + C' to cancel it**. 
+**Note: The model can still make mistakes! Don't run a command if you don't understand it. If you're not sure what a command does, hit `Ctrl + C` to cancel it**.
 
 This project took technical inspiration from the [zsh_codex](https://github.com/tom-doerr/zsh_codex) project, extending its functionality to span multiple shells and to customize the prompts passed to the model (see prompt engineering section below).
 
@@ -32,9 +32,9 @@ Please follow the installation instructions for PowerShell, bash or zsh from [he
 
 ## Usage
 
-Once configured for your shell of preference, you can use the Codex CLI by writing a comment (starting with `#`) into your shell, and then hitting Ctrl + G. 
+Once configured for your shell of preference, you can use the Codex CLI by writing a comment (starting with `#`) into your shell, and then hitting `Ctrl + G`.
 
-The Codex CLI supports two primary modes: single-turn and multi-turn. 
+The Codex CLI supports two primary modes: single-turn and multi-turn.
 
 By default, multi-turn mode is off. It can be toggled on and off using the `# start multi-turn` and `# stop multi-turn` commands.
 

--- a/contexts/CognitiveServiceContext.md
+++ b/contexts/CognitiveServiceContext.md
@@ -2,7 +2,7 @@
 
 ## Using Speech Synthesis
 
-This project includes speech synthesized playback for your query outputs using the azure cognitive services speech cli. As noted in the previous section about contexts, this is a certain behaviour of the model that is included in the sample `powershell-voice-cognitive-service.txt` file available in the `contexts` folder. Before running any speech synthesis output from the model, you have to do a couple of steps to set it up: 
+This project includes speech synthesized playback for your query outputs using the azure cognitive services speech cli. As noted in the previous section about contexts, this is a certain behavior of the model that is included in the sample `powershell-voice-cognitive-service.txt` file available in the `contexts` folder. Before running any speech synthesis output from the model, you have to do a couple of steps to set it up: 
 
 ### Set up Azure Speech Service
 
@@ -21,7 +21,7 @@ Follow the instructions in [Azure Speech CLI Quickstart](https://docs.microsoft.
 If you are setting up for the first time, here is what you may have to do: 
 1. Download [.NET Core 3.1 SDK](https://docs.microsoft.com/en-us/dotnet/core/install/windows) and [Microsoft Visual C++ Redistributable for Visual Studio 2019](https://support.microsoft.com/help/2977003/the-latest-supported-visual-c-downloads)
 2. Install speech CLI in PowerShell using this command: `dotnet tool install --global Microsoft.CognitiveServices.Speech.CLI`
-3. Use the subsription key and region that you obtained from the Cognitive Services Speech Service page and input into the following commands
+3. Use the subscription key and region that you obtained from the Cognitive Services Speech Service page and input into the following commands
 
 `spx config @key --set SUBSCRIPTION-KEY`  
 `spx config @region --set REGION`

--- a/contexts/CognitiveServiceContext.md
+++ b/contexts/CognitiveServiceContext.md
@@ -28,7 +28,7 @@ If you are setting up for the first time, here is what you may have to do:
 
 ### Load the example speech context file
 
-Load the example Cognitive Services speech context file using  ` # load context powershell-voice-cognitive-service.txt ` and then hit Ctrl + G to let the Codex CLI load the file
+Load the example Cognitive Services speech context file using  ` # load context powershell-voice-cognitive-service.txt ` and then hit `Ctrl + G` to let the Codex CLI load the file
 
 And that's it! To get started with an example, go ahead and type `# whats the meaning of life`.
 You can develop your own context with more speech functions as mentioned in the previous section. 

--- a/scripts/bash_setup.sh
+++ b/scripts/bash_setup.sh
@@ -93,7 +93,7 @@ configureApp()
     chmod +x "$CODEX_CLI_PATH/src/codex_query.py"
 }
 
-# Create and load ~/.codexclirc to setup bash CTRL-g binding
+# Create and load ~/.codexclirc to setup bash 'Ctrl + G' binding
 configureBash()
 {
     echo "*** Configuring bash [$BASH_RC_FILE] ***"
@@ -181,7 +181,7 @@ cleanupEnv
 
 echo -e "*** Setup complete! ***\n";
 
-echo "**********************************************"
+echo "***********************************************"
 echo "Open a new Bash terminal, type '#' followed by"
-echo "your natural language command and hit Ctrl+g!"
-echo "**********************************************"
+echo "your natural language command and hit Ctrl + G!"
+echo "***********************************************"

--- a/scripts/zsh_setup.sh
+++ b/scripts/zsh_setup.sh
@@ -39,7 +39,7 @@ validateSettings()
     echo "OK ***"
 }
 
-# Append settings and CTRL-g binding in .zshrc
+# Append settings and 'Ctrl + G' binding in .zshrc
 configureZsh()
 {
     # Remove previous settings
@@ -113,7 +113,7 @@ configureApp
 
 echo -e "*** Setup complete! ***\n";
 
-echo "**********************************************"
+echo "***********************************************"
 echo "Open a new zsh terminal, type '#' followed by"
-echo "your natural language command and hit Ctrl+g!"
-echo "**********************************************"
+echo "your natural language command and hit Ctrl + G!"
+echo "***********************************************"


### PR DESCRIPTION
* Fix docs inconsistencies around `Ctrl + `  keyboard shortcuts (see https://github.com/microsoft/Codex-CLI/issues/112)
* Fix some doc typos and formatting