### PR TITLE
Fix sed usage in scripts/zsh_setup.sh

### DIFF
--- a/scripts/zsh_setup.sh
+++ b/scripts/zsh_setup.sh
@@ -43,7 +43,7 @@ validateSettings()
 configureZsh()
 {
     # Remove previous settings
-    sed -i '' '/### Codex CLI setup - start/,/### Codex CLI setup - end/d' $zshrcPath
+    sed -i'' '/### Codex CLI setup - start/,/### Codex CLI setup - end/d' "$(readlink -f $zshrcPath)"
     echo "Removed previous settings in $zshrcPath if present"
 
     # Update the latest settings


### PR DESCRIPTION
* Follow symlinks when changing zhsrc (e.g. when zshrc is managed by dotfiles manager like dotbot). Otherwise it substitutes symlinks with an ordinary file.
* GNU sed doesn't seem to work with `-i ''`, only with `-i''`.