### PR TITLE
Add zinit support

### DIFF
--- a/Installation.md
+++ b/Installation.md
@@ -115,6 +115,15 @@ $ git clone https://github.com/microsoft/Codex-CLI.git ~/your/custom/path/
 
 3. Run `zsh`, start typing and complete it using `^G`!
 
+### Using [zinit](https://github.com/zdharma-continuum/zinit) to install
+
+1. Add below settings to your zshrc
+
+```
+zinit ice lucid wait atclone"./scripts/zsh_setup.sh -a" src"scripts/zsh_plugin.zsh" atload"bindkey '^G' create_completion"
+zinit light microsoft/Codex-CLI.git
+```
+
 ### Clean up
 Once you are done, go to `~/your/custom/path/` (the folder contains Codex CLI code), then run the following command to clean up.
 ```

--- a/scripts/zsh_plugin.zsh
+++ b/scripts/zsh_plugin.zsh
@@ -1,7 +1,11 @@
 #!/bin/zsh
 
-# This ZSH plugin reads the text from the current buffer 
+# This ZSH plugin reads the text from the current buffer
 # and uses a Python script to complete the text.
+
+if [[ -z "$CODEX_CLI_PATH" ]];then
+export CODEX_CLI_PATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )/../"
+fi
 
 create_completion() {
     # Get the text typed until now.

--- a/scripts/zsh_setup.sh
+++ b/scripts/zsh_setup.sh
@@ -9,7 +9,7 @@
 #
 # For example:
 # ./zsh_setup.sh -o <YOUR_ORG_ID> -k <YOUR_API_KEY> -e <ENGINE_ID>
-# 
+#
 set -e
 
 # Call OpenAI API with the given settings to verify everythin is in order
@@ -52,7 +52,7 @@ configureZsh()
     echo "source \"\$CODEX_CLI_PATH/scripts/zsh_plugin.zsh\"" >> $zshrcPath
     echo "bindkey '^G' create_completion" >> $zshrcPath
     echo "### Codex CLI setup - end" >> $zshrcPath
-    
+
     echo "Added settings in $zshrcPath"
 }
 
@@ -63,7 +63,7 @@ configureApp()
     echo "organization_id=$orgId" >> $openAIConfigPath
     echo "secret_key=$secret" >> $openAIConfigPath
     echo "engine=$engineId" >> $openAIConfigPath
-    
+
     echo "Updated OpenAI configuration file ($openAIConfigPath) with secrets"
 
     # Change file mode of codex_query.py to allow execution
@@ -108,8 +108,20 @@ validateSettings
 openAIConfigPath="$CODEX_CLI_PATH/src/openaiapirc"
 zshrcPath="$HOME/.zshrc"
 
-configureZsh
-configureApp
+if [ -z "$1" ]; then
+   configureZsh
+   configureApp
+else
+    while [[ "$#" -gt 0 ]]
+    do case $1 in
+        -a|--app-only) configureApp
+        shift;;
+        *) echo "Unknown parameter passed: $1"
+        exit 1;;
+    esac
+    shift
+    done
+fi
 
 echo -e "*** Setup complete! ***\n";
 


### PR DESCRIPTION
1. Adding an example to the readme to show how to install this exciting tool via Zinit. 
2. Since Zinit support configure the plugin automatically, adding an option to configure App only.
3. export `CODEX_CLI_PATH` base on the path of scripts/zsh_plugin.zsh